### PR TITLE
Changed how class types are registered

### DIFF
--- a/latte/src/main/java/typechecking/LatteClassFirstPass.java
+++ b/latte/src/main/java/typechecking/LatteClassFirstPass.java
@@ -24,8 +24,8 @@ public class LatteClassFirstPass extends LatteAbstractChecker{
     public <T> void visitCtClass(CtClass<T> ctClass) {
 		logInfo("Visiting class: " + ctClass.getSimpleName());
 		// Add the class to the type reference and class map
-		CtTypeReference<?> typeRef = ctClass.getReference();
-		maps.addTypeClass(typeRef, ctClass);
+		CtTypeReference<?> typeRef1 = ctClass.getReference();
+		maps.addTypeClass(typeRef1, ctClass);
 		super.visitCtClass(ctClass);
 	}
 			

--- a/latte/src/main/java/typechecking/LatteTypeChecker.java
+++ b/latte/src/main/java/typechecking/LatteTypeChecker.java
@@ -199,7 +199,7 @@ public class LatteTypeChecker  extends LatteAbstractChecker {
 			invocation.getArguments().size());
 
 		if (m == null){
-			logInfo("Cannot find method {"+ metName +"} for class {"+ klass.getSimpleName() +"} with {"+ paramSize +"} in the context");
+			logInfo("Cannot find method {" + metName + "} for {} in the context");
 			return;
 		}
 		List<SymbolicValue> paramSymbValues = new ArrayList<>();

--- a/latte/src/main/java/typechecking/LatteTypeChecker.java
+++ b/latte/src/main/java/typechecking/LatteTypeChecker.java
@@ -191,7 +191,7 @@ public class LatteTypeChecker  extends LatteAbstractChecker {
 		if (invocation.getTarget() == null){
 			logError("Invocation needs to have a target but found none -", invocation);
 		}
-		CtTypeReference<?> e = invocation.getTarget().getType();
+		CtTypeReference<?> e = invocation.getTarget().getType().getTypeErasure();
 		
 		// method(Γ(𝑥), 𝑓 ) = 𝛼 𝐶 𝑚(𝛼0 𝐶0 this, 𝛼1 𝐶1 𝑥1, · · · , 𝛼𝑛 𝐶𝑛 𝑥𝑛 )
 		CtClass<?> klass = maps.getClassFrom(e);
@@ -199,7 +199,7 @@ public class LatteTypeChecker  extends LatteAbstractChecker {
 			invocation.getArguments().size());
 
 		if (m == null){
-			logInfo(String.format("Cannot find method {} for {} in the context", metName, invocation.getType()));
+			logInfo("Cannot find method {"+ metName +"} for class {"+ klass.getSimpleName() +"} with {"+ paramSize +"} in the context");
 			return;
 		}
 		List<SymbolicValue> paramSymbValues = new ArrayList<>();


### PR DESCRIPTION
## Description
Changed how class types are registered in the ClassLevelMaps to be coherent with how they are searched.

## Example
A Class type would be added by the method VisitCtClass(...) in LatteClassFirstPass as "LinkedList",
but would be searched for by the method visitCtInvocation(...) in LatteTypeChecker as "LinkedList<String>" (for example), leading to a miss.
Was fixed by using .getTypeErasure() on visitCtInvocation(...), simplifying to "LinkedList" in every case

## Related Issue
#6 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## How Has This Been Tested?
App.java was run and the previously known bug was found.
Adding other instances of the same class but with different Types did not affect the correctness of the output.