### PR TITLE
Add test execution and upload test results in Maven CI workflow inside target/

### DIFF
--- a/.github/workflows/maven-2.yml
+++ b/.github/workflows/maven-2.yml
@@ -35,7 +35,7 @@ jobs:
       run: mvn test --file pom.xml
     - name: Upload test results
       if: always()  # This ensures the test results are uploaded even if tests fail
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-results
         path: latte/latte/target/test-*.xml  # Maven Surefire generates the test result files here

--- a/.github/workflows/maven-2.yml
+++ b/.github/workflows/maven-2.yml
@@ -35,7 +35,7 @@ jobs:
       run: mvn test --file pom.xml
     - name: Upload test results
       if: always()  # This ensures the test results are uploaded even if tests fail
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.6.2
       with:
         name: test-results
         path: latte/latte/target/test-*.xml  # Maven Surefire generates the test result files here

--- a/.github/workflows/maven-2.yml
+++ b/.github/workflows/maven-2.yml
@@ -30,7 +30,15 @@ jobs:
     - name: Build with Maven
       working-directory: latte
       run: mvn -B package --file pom.xml
-
+    - name: Run tests with Maven
+      working-directory: latte
+      run: mvn test --file pom.xml
+    - name: Upload test results
+      if: always()  # This ensures the test results are uploaded even if tests fail
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: latte/latte/target/test-*.xml  # Maven Surefire generates the test result files here
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       run: |


### PR DESCRIPTION


Updated the GitHub Actions workflow to run unit tests after building the project and upload the test results as artifacts, even if the tests fail. This helps in easily identifying and debugging issues in the code.

