### PR TITLE
If e1 Then s1 'Else skip' adaptation

### DIFF
--- a/latte/src/main/java/typechecking/LatteTypeChecker.java
+++ b/latte/src/main/java/typechecking/LatteTypeChecker.java
@@ -532,11 +532,21 @@ public class LatteTypeChecker  extends LatteAbstractChecker {
 		PermissionEnvironment thenPermEnv = permEnv.cloneLast();
 		exitScopes();
 
-		enterScopes();
-		super.visitCtBlock(ifElement.getElseStatement());
-		SymbolicEnvironment elseSymbEnv = symbEnv.cloneLast();
-		PermissionEnvironment elsePermEnv = permEnv.cloneLast();
-		exitScopes();
+		SymbolicEnvironment elseSymbEnv;
+    	PermissionEnvironment elsePermEnv;
+
+		if (ifElement.getElseStatement() != null) {
+			//Else statement
+			enterScopes();
+			super.visitCtBlock(ifElement.getElseStatement());
+			elseSymbEnv = symbEnv.cloneLast();
+			elsePermEnv = permEnv.cloneLast();
+			exitScopes();
+		} else {
+			//No Else statement
+			elseSymbEnv = symbEnv.cloneLast();
+			elsePermEnv = permEnv.cloneLast();
+		}
 
 		joining(thenSymbEnv, thenPermEnv, elseSymbEnv, elsePermEnv);
 	}


### PR DESCRIPTION
## Description
Simulated an "Else { skip; }" when no else expression is present in the original code.

## Related Issue
#11 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## How Has This Been Tested?
Some simple feature tests were ran locally, with no found bugs
